### PR TITLE
Bring `main` up to date with latest CRSF implementation from `dev-CRSF`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WingFC
 
-### Latest Version 0.2.2
+### Latest Version 0.2.3
 
 WingFC is a specialized open-source embedded flight controller designed specifically for the rapidly growing sub-250g flying wing FPV (First-Person-View) market. The project's core mission is to provide a reliable, user-friendly, and highly customizable solution for hobbyists and enthusiasts building ultra-lightweight Unmanned Aerial Vehicles (UAVs).
 
@@ -35,7 +35,7 @@ What things you need to install the software and how to install them
 
 ### Installing
 
-[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.2)
+[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.3)
 Extract source code then navigate to the top directory of the source.
 ```
 cd firmware/src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WingFC
 
-### Latest Version 0.2.3
+### Latest Version 0.2.2
 
 WingFC is a specialized open-source embedded flight controller designed specifically for the rapidly growing sub-250g flying wing FPV (First-Person-View) market. The project's core mission is to provide a reliable, user-friendly, and highly customizable solution for hobbyists and enthusiasts building ultra-lightweight Unmanned Aerial Vehicles (UAVs).
 
@@ -35,7 +35,7 @@ What things you need to install the software and how to install them
 
 ### Installing
 
-[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.3)
+[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.2)
 Extract source code then navigate to the top directory of the source.
 ```
 cd firmware/src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WingFC
 
-### Latest Version 0.2.3
+### Latest Version 0.2.2
 
 WingFC is a specialized open-source embedded flight controller designed specifically for the rapidly growing sub-250g flying wing FPV (First-Person-View) market. The project's core mission is to provide a reliable, user-friendly, and highly customizable solution for hobbyists and enthusiasts building ultra-lightweight Unmanned Aerial Vehicles (UAVs).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What things you need to install the software and how to install them
 
 ### Installing
 
-[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.3)
+[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.1)
 Extract source code then navigate to the top directory of the source.
 ```
 cd firmware/src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WingFC
 
-### Latest Version 0.2.2
+### Latest Version 0.2.3
 
 WingFC is a specialized open-source embedded flight controller designed specifically for the rapidly growing sub-250g flying wing FPV (First-Person-View) market. The project's core mission is to provide a reliable, user-friendly, and highly customizable solution for hobbyists and enthusiasts building ultra-lightweight Unmanned Aerial Vehicles (UAVs).
 
@@ -35,7 +35,7 @@ What things you need to install the software and how to install them
 
 ### Installing
 
-[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.1)
+[Download source code](https://github.com/BryanSouza91/WingFC/releases/tag/v0.2.3)
 Extract source code then navigate to the top directory of the source.
 ```
 cd firmware/src

--- a/firmware/src/crsf.go
+++ b/firmware/src/crsf.go
@@ -185,12 +185,12 @@ func calculateCrc8(data []byte) byte {
 	return crc
 }
 
-// ticksToUs converts the 11-bit channel value (172-1811) to microseconds (987-2012).
+// ticksToUs converts the 11-bit channel value (172-1811) to microseconds (988-2012).
 func ticksToUs(ticks uint16) uint16 {
 	return uint16(ticks * 5 / 8 + 880)
 }
 
-// usToTicks converts microseconds (987-2012) to the 11-bit channel value (172-1811).
+// usToTicks converts microseconds (988-2012) to the 11-bit channel value (172-1811).
 func usToTicks(us uint16) uint16 {
 	return uint16(us * 8 / 5 + 880)
 }

--- a/firmware/src/crsf.go
+++ b/firmware/src/crsf.go
@@ -161,9 +161,14 @@ func processReceiverPacket(payload [CRSF_PACKET_SIZE]byte) [NumChannels]uint16 {
 			bitsMerged += 8
 		}
 		channelValues[n] = uint16(readValue & 0x07FF)
+
+		// Based on CRSF spec, https://github.com/tbs-fpv/tbs-crsf-spec/blob/main/crsf.md#0x16-rc-channels-packed-payload
+		//usec = 1500 + (ticks-992)*5/8
+		channelValues[n] = 880 + (channelValues[n])*5/8 // probably not ideal
 		readValue >>= 11
 		bitsMerged -= 11
 	}
+	Channels = channelValues
 	return channelValues
 }
 

--- a/firmware/src/crsf.go
+++ b/firmware/src/crsf.go
@@ -192,5 +192,5 @@ func ticksToUs(ticks uint16) uint16 {
 
 // usToTicks converts microseconds (988-2012) to the 11-bit channel value (172-1811).
 func usToTicks(us uint16) uint16 {
-	return uint16(us * 8 / 5 + 880)
+	return uint16((us - 880) * 8 / 5)
 }

--- a/firmware/src/crsf.go
+++ b/firmware/src/crsf.go
@@ -187,10 +187,10 @@ func calculateCrc8(data []byte) byte {
 
 // ticksToUs converts the 11-bit channel value (172-1811) to microseconds (987-2012).
 func ticksToUs(ticks uint16) uint16 {
-	return uint16(float64(ticks - 992) * 5 / 8 + 1500)
+	return uint16(ticks * 5 / 8 + 880)
 }
 
 // usToTicks converts microseconds (987-2012) to the 11-bit channel value (172-1811).
 func usToTicks(us uint16) uint16 {
-	return uint16(float64(us - 1500) * 8 / 5 + 992)
+	return uint16(us * 8 / 5 + 880)
 }

--- a/firmware/src/crsf.go
+++ b/firmware/src/crsf.go
@@ -160,9 +160,10 @@ func processReceiverPacket(payload [CRSF_PACKET_SIZE]byte) [NumChannels]uint16 {
 			readValue |= uint32(readByte) << bitsMerged
 			bitsMerged += 8
 		}
-		channelValues[n] = uint16(readValue & 0x07FF)
+		channelValues[n] = uint16(readValue & 0x07FF) // Mask to 11 bits
 		readValue >>= 11
 		bitsMerged -= 11
+		channelValues[n] = ticksToUs(channelValues[n]) // Convert to microseconds
 	}
 	return channelValues
 }
@@ -182,4 +183,14 @@ func calculateCrc8(data []byte) byte {
 		}
 	}
 	return crc
+}
+
+// ticksToUs converts the 11-bit channel value (172-1811) to microseconds (987-2012).
+func ticksToUs(ticks uint16) uint16 {
+	return uint16(float64(ticks - 992) * 5 / 8 + 1500)
+}
+
+// usToTicks converts microseconds (987-2012) to the 11-bit channel value (172-1811).
+func usToTicks(us uint16) uint16 {
+	return uint16(float64(us - 1500) * 8 / 5 + 992)
 }

--- a/firmware/tests/crsf.go
+++ b/firmware/tests/crsf.go
@@ -145,9 +145,10 @@ func processReceiverPacket(payload [CRSF_PACKET_SIZE]byte) {
 			readValue |= uint32(readByte) << bitsMerged
 			bitsMerged += 8
 		}
-		channelValues[n] = uint16(readValue & 0x07FF)
+		channelValues[n] = uint16(readValue & 0x07FF) // Mask to 11 bits
 		readValue >>= 11
 		bitsMerged -= 11
+		println("Channel", n+1, "ticks:", channelValues[n], "us:", ticksToUs(channelValues[n]))
 	}
 	Channels = channelValues
 }
@@ -167,4 +168,14 @@ func calculateCrc8(data []byte) byte {
 		}
 	}
 	return crc
+}
+
+// ticksToUs converts the 11-bit channel value (172-1811) to microseconds (987-2012).
+func ticksToUs(ticks uint16) uint16 {
+	return uint16(ticks * 5 / 8 + 880)
+}
+
+// usToTicks converts microseconds (987-2012) to the 11-bit channel value (172-1811).
+func usToTicks(us uint16) uint16 {
+	return uint16(us * 8 / 5 + 880)
 }


### PR DESCRIPTION
Updated `crsf.go` to adjust the pulse widths to the appropriate range for the flight control loop.